### PR TITLE
Update React Native pay SDK. Remove a:9 for single item URL or QR

### DIFF
--- a/src/XcooBeePay.ts
+++ b/src/XcooBeePay.ts
@@ -244,10 +244,7 @@ export class XcooBeePaySDK implements XcooBeePayBase, XcooBeePayUrl, XcooBeePayQ
     const securePayItem = this.makeSecurePayItem({
       amount,
       reference,
-      tax,
-      logic: [{
-        a: SecurePayItemActions.userEntry
-      }]
+      tax
     });
 
     return this.makePayUrl([securePayItem], config);


### PR DESCRIPTION
remove user entry action from createSingleItemUrl method